### PR TITLE
heater bed standby temp fix

### DIFF
--- a/src/PanelDue.cpp
+++ b/src/PanelDue.cpp
@@ -747,7 +747,7 @@ void ProcessReceivedValue(const char id[], const char data[], const size_t indic
 		ShowLine;
 		{
 			int32_t ival;
-			if (GetInteger(data, ival) && indices[0] < (int)maxHeaters && indices[0] != 0)
+			if (GetInteger(data, ival) && indices[0] < maxHeaters)
 			{
 				UI::UpdateStandbyTemperature(indices[0], ival);
 			}

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1521,7 +1521,13 @@ namespace UI
 					case evAdjustStandbyTemp:
 						{
 							int heater = fieldBeingAdjusted.GetIParam();
-							if (heater > 0)
+							if (heater == 0)
+							{
+								SerialIo::SendString("M140 R");
+								SerialIo::SendInt(val);
+								SerialIo::SendChar('\n');
+							}
+							else
 							{
 								SerialIo::SendString("G10 P");
 								SerialIo::SendInt(heater - 1);


### PR DESCRIPTION
Remove limitation of always showing 0 and not setting bed heater standby temperature.

I noticed that on the PanelDue I could not see or set the bed standby temperature. Found that it was disabled in the code for some reason.

I am not sure of the reason and if there should be some feature tests for this but with these changes I can now see and set the standby bed temperature.