### PR TITLE
Minor changes to dimming code

### DIFF
--- a/src/Events.hpp
+++ b/src/Events.hpp
@@ -58,6 +58,7 @@ enum Event : uint8_t
 	evAdjustLanguage, evSetLanguage,
 	evAdjustColours, evSetColours,
 	evBrighter, evDimmer,
+	evSetDimmingType,
 
 	evRestart, evEmergencyStop,
 

--- a/src/PanelDue.cpp
+++ b/src/PanelDue.cpp
@@ -612,6 +612,9 @@ void SetStatus(char c)
 	
 		status = newStatus;
 		UI::UpdatePrintingFields();
+
+		// if the status changed, illuminate the screen
+		RestoreBrightness();
 	}
 }
 

--- a/src/PanelDue.cpp
+++ b/src/PanelDue.cpp
@@ -496,6 +496,13 @@ extern void RestoreBrightness()
 {
 	Buzzer::SetBacklight(nvData.brightness);
 	isDimmed = false;
+	lastActionTime = SystemTick::GetTickCount();
+}
+
+extern void DimBrightness()
+{
+	Buzzer::SetBacklight(nvData.brightness >> 3);
+	isDimmed = true;
 }
 
 void SetVolume(uint32_t newVolume)
@@ -1319,8 +1326,7 @@ int main(void)
 			}
 			else if (!isDimmed && SystemTick::GetTickCount() - lastActionTime >= DimDisplayTimeout)
 			{
-				Buzzer::SetBacklight(nvData.brightness/8);
-				isDimmed = true;
+				DimBrightness();
 			}
 		}
 		ShowLine;

--- a/src/PanelDue.hpp
+++ b/src/PanelDue.hpp
@@ -40,6 +40,7 @@ extern void InvertDisplay();
 extern void SetBaudRate(uint32_t rate);
 extern void SetBrightness(int percent);
 extern void RestoreBrightness();
+extern void DimBrightness();
 extern void SetVolume(uint32_t newVolume);
 extern void SetColourScheme(uint32_t newColours);
 extern void SetLanguage(uint32_t newLanguage);

--- a/src/PanelDue.hpp
+++ b/src/PanelDue.hpp
@@ -31,6 +31,14 @@ extern void ErrorBeep();
 extern void CalibrateTouch();
 
 // Functions called from module UserInterface to manipulate non-volatile settings and associated hardware
+enum DisplayDimmerTypes : uint8_t
+{
+	DISPLAYDIMMER_ALWAYS = 0,		// default - always dim
+	DISPLAYDIMMER_NEVER = 1,		// never dim the display
+	DISPLAYDIMMER_ONIDLE = 2, 		// only display when printer status is idle
+
+	DISPLAYDIMMER_MAX = 2,
+};
 extern void FactoryReset();
 extern void SaveSettings();
 extern bool IsSaveAndRestartNeeded();
@@ -47,6 +55,10 @@ extern void SetLanguage(uint32_t newLanguage);
 extern uint32_t GetBaudRate();
 extern int GetBrightness();
 extern uint32_t GetVolume();
+extern DisplayDimmerTypes GetDisplayDimmerType();
+extern void SetDisplayDimmerType(DisplayDimmerTypes newType);
+
+
 extern FirmwareFeatures GetFirmwareFeatures();
 extern const char* array CondStripDrive(const char* array arg);
 extern void Reconnect();
@@ -83,5 +95,7 @@ struct Alert
 
 	Alert() { flags = 0; }
 };
+
+
 
 #endif /* PANELDUE_H_ */

--- a/src/Strings.hpp
+++ b/src/Strings.hpp
@@ -238,8 +238,8 @@ const StringTable LanguageTables[4] =
 		// Print page
 		"Extruder" THIN_SPACE "%",
 		"Speed ",							// note space at end. Was "Geschwindigkeit " but that is too long to fit in the space available.
-		"LÃ¼fter ",							// note space at end
-		"Zeit Ã¼brig: ",
+		"Lüfter ",							// note space at end
+		"Zeit übrig: ",
 		"Datei ",							// note space at end
 		", Filament ",						// note space at end
 		", Schicht ",						// note space at end
@@ -251,7 +251,7 @@ const StringTable LanguageTables[4] =
 		"Set",
 
 		// Setup page
-		"LautstÃ¤rke ",						// note space at end
+		"Lautstärke ",						// note space at end
 		"Touch kalibrieren",
 		"Anzeige spiegeln",
 		"Anzeige invertieren",
@@ -259,24 +259,24 @@ const StringTable LanguageTables[4] =
 		"Helligkeit -",
 		"Helligkeit +",
 		"Einstellungen speichern",
-		"Einstellungen lÃ¶schen",
+		"Einstellungen löschen",
 		"Speichern & Neustarten",
 
 		// Misc
-		"RÃ¼cksetzen bestÃ¤tigen",
-		"Neustart bestÃ¤tigen",
-		"LÃ¶schen bestÃ¤tigen",
+		"Rücksetzen bestätigen",
+		"Neustart bestätigen",
+		"Löschen bestätigen",
 		"Sind sie sicher?",
-		"BerÃ¼hren sie den Punkt",
+		"Berühren sie den Punkt",
 		"Einige Einstellungen sind nicht gespeichert!",
-		"BerÃ¼hren sie Speichern & Neustarten um die neuen Einstellungen anzuwenden",
+		"Berühren sie Speichern & Neustarten um die neuen Einstellungen anzuwenden",
 		"Neustarten erforderlich",
 		"Neustarten jetzt?",
 		"Kopf bewegen",
 		"Extrusionsmenge (mm)",
 		"Geschwindigkeit (mm/s)",
 		"Extrudieren",
-		"ZurÃ¼ckziehen",
+		"Zurückziehen",
 		"Babystepping",
 		"Aktueller Z-Versatz: ",
 		"Nachricht",
@@ -289,10 +289,10 @@ const StringTable LanguageTables[4] =
 		"Fehler ",						// note the space at the end
 		" beim Zugriff auf SD-Karte",	// note the space at the start
 		"Dateiname: ",
-		"GrÃ¶ÃŸe: ",
-		"SchichthÃ¶he: ",
-		"ObjekthÃ¶he: ",
-		"BenÃ¶tigtes Filament: ",
+		"Größe: ",
+		"Schichthöhe: ",
+		"Objekthöhe: ",
+		"Benötigtes Filament: ",
 		"Erzeugt mit: ",
 		"Simulieren",
 
@@ -304,7 +304,7 @@ const StringTable LanguageTables[4] =
 			"Angehalten",
 			"Starte",
 			"Pausiert",
-			"BeschÃ¤ftigt",
+			"Beschäftigt",
 			"Pausiere",
 			"Fortsetzen",
 			"Firmware-Upload",
@@ -324,17 +324,15 @@ const StringTable LanguageTables[4] =
 			"Nie dämmern",
 			"Idle Dim"
 		}
-
-
 	},
 
 	// French
 	{
 		// Language name
-		"FranÃ§ais",
+		"Français",
 
 		// Main page strings
-		"ContrÃ´le",
+		"Contrôle",
 		"Imprimer",
 		"Console",
 		"Installation",
@@ -344,7 +342,7 @@ const StringTable LanguageTables[4] =
 		"Mouvement",
 		"Extrusion",
 		"Macro",
-		"ARRÃŠT",
+		"ARRÊT",
 
 		// Print page
 		"Extrudeuse" THIN_SPACE "%",
@@ -364,32 +362,32 @@ const StringTable LanguageTables[4] =
 		// Setup page
 		"Volume ",								// note space at end
 		"Calibrer touch",
-		"Affichage en nÃ©gatif",
+		"Affichage en négatif",
 		"Inverser affichage",
-		"ThÃ©me",
-		"LuminositÃ© -",
-		"LuminositÃ© +",
-		"Sauver paramÃªtres",
-		"Effacer paramÃªtres",
-		"Sauvegarde & RedÃ©marrage",
+		"Théme",
+		"Luminosité -",
+		"Luminosité +",
+		"Sauver paramêtres",
+		"Effacer paramêtres",
+		"Sauvegarde & Redémarrage",
 
 		// Misc
-		"Confirmer le rÃ©initialisation de l'imprimante",
-		"Confirm RedÃ©marrage",
+		"Confirmer le réinitialisation de l'imprimante",
+		"Confirm Redémarrage",
 		"Confirm suppression fichier",
-		"Vous Ãªtes sÃ»re?",
+		"Vous êtes sûre?",
 		"Appuyer sur le point",
-		"Certains rÃ©glages ne sont pas sauvegardÃ©s!",
-		"Appuyer sur Sauvegarde et RedÃ©marrage pour utiliser les nouveaux rÃ©glages",
+		"Certains réglages ne sont pas sauvegardés!",
+		"Appuyer sur Sauvegarde et Redémarrage pour utiliser les nouveaux réglages",
 		"Restart required",
 		"Restart now?",
-		"Mouvement de la  tÃªte",
-		"QuantitÃ© de MatiÃ©re extrudÃ©e (mm)",
+		"Mouvement de la  tête",
+		"Quantité de Matiére extrudée (mm)",
 		"Vitesse (mm/s)",
 		"Extruder",
 		"Retracter",
 		"Baby stepping",
-		"dÃ©calage Z courant : ",
+		"décalage Z courant : ",
 		"Message",
 		"Messages",
 		"Version du firmware du Panel Due ",	// note space at end
@@ -398,7 +396,7 @@ const StringTable LanguageTables[4] =
 		"Fichier sur carte ",					// note the space on the end
 		"Macros",
 		"Erreur ",								// note the space at the end
-		" accÃ©s SD card en cours",				// note the space at the start
+		" accés SD card en cours",				// note the space at the start
 		"Nom du fichier : ",
 		"Taille : ",
 		"Hauteur de couche: ",
@@ -412,13 +410,13 @@ const StringTable LanguageTables[4] =
 			"Connection en cours",
 			"Au repos",
 			"Impression",
-			"ArrÃªt",
-			"DÃ©marrage",
+			"Arrêt",
+			"Démarrage",
 			"Pause",
-			"OccupÃ©"
+			"Occupé"
 			"Pause",
 			"Reprise",
-			"TÃ©leverser le firmware",
+			"Téleverser le firmware",
 			"Changement d'outil",
 			"Simuler"
 		},
@@ -435,21 +433,20 @@ const StringTable LanguageTables[4] =
 			"Jamais Dim",
 			"Idle Dim"
 		}
-
 	},
 	// Czech
 		{
 			// Language name
-			"ÄŒeÅ¡tina",
+			"Čeština",
 
 			// Main page strings
-			"OvlÃ¡dÃ¡nÃ­",
+			"Ovládání",
 			"Tisk",
 			"Konzole",
-			"NastavenÃ­",
-			"AktuÃ¡lnÃ­" THIN_SPACE DEGREE_SYMBOL "C",
-			"AktivnÃ­" THIN_SPACE DEGREE_SYMBOL "C",
-			"NeÄ�innÃ¡" THIN_SPACE DEGREE_SYMBOL "C",
+			"Nastavení",
+			"Aktuální" THIN_SPACE DEGREE_SYMBOL "C",
+			"Aktivní" THIN_SPACE DEGREE_SYMBOL "C",
+			"Nečinná" THIN_SPACE DEGREE_SYMBOL "C",
 			"Pohyb",
 			"Extruder",
 			"Makra",
@@ -459,90 +456,89 @@ const StringTable LanguageTables[4] =
 			"Extruder" THIN_SPACE "%",
 			"Rychl. ",							// note space at end
 			"Vent. ",							// note space at end
-			"ÄŒas do konce: ",
+			"Čas do konce: ",
 			"soubor ",							// note space at end
-			", materiÃ¡l ",						// note space at end
+			", materiál ",						// note space at end
 			", vrstva ",							// note space at end
 			"n/a",
 			"Pozastavit",
 			"Baby step",
-			"PokraÄ�ovat",
-			"ZruÅ¡it",
+			"Pokračovat",
+			"Zrušit",
 			"OK",
 
 			// Setup page
 			"Hlasitost ",							// note space at end
 			"Kalibrace dotyku",
 			"Zrcadlit displej",
-			"ObrÃ¡tit displej",
+			"Obrátit displej",
 			"Motiv",
-			"PodsvÃ­cenÃ­ -",
-			"PodsvÃ­cenÃ­ +",
-			"UloÅ¾it nastavenÃ­",
-			"Smazat nastavenÃ­",
-			"UloÅ¾it a Restart",
+			"Podsvícení -",
+			"Podsvícení +",
+			"Uložit nastavení",
+			"Smazat nastavení",
+			"Uložit a Restart",
 
 			// Misc
-			"SkuteÄ�nÄ› obnovit tovÃ¡rnÃ­ nastavenÃ­?",
+			"Skutečně obnovit tovární nastavení?",
 			"Restartovat?",
-			"SkuteÄ�nÄ› smazat?",
-			"UrÄ�itÄ›?",
-			"DotknÄ›te se bodu",
-			"NÄ›kterÃ¡ nastavenÃ­ nejsou uloÅ¾ena!",
-			"Zvolte UloÅ¾it a Restart pro dokonÄ�enÃ­",
-			"VyÅ¾adovÃ¡n restart",
-			"Restartovat nynÃ­?",
+			"Skutečně smazat?",
+			"Určitě?",
+			"Dotkněte se bodu",
+			"Některá nastavení nejsou uložena!",
+			"Zvolte Uložit a Restart pro dokončení",
+			"Vyžadován restart",
+			"Restartovat nyní?",
 			"Posun hlavy",
-			"MnoÅ¾stvÃ­ (mm)",
+			"Množství (mm)",
 			"Rychlost (mm/s)",
-			"VytlaÄ�it (extr.)",
-			"ZatlaÄ�it (retr.)",
+			"Vytlačit (extr.)",
+			"Zatlačit (retr.)",
 			"Baby stepping",
-			"AktuÃ¡lnÃ­ Z offset: ",
-			"ZprÃ¡va",
-			"ZprÃ¡vy",
+			"Aktuální Z offset: ",
+			"Zpráva",
+			"Zprávy",
 			"Verze firmware Panel Due ",	// note space at end
 			// File popup
-			"Soubory na kartÄ› ",				// note the space on the end
+			"Soubory na kartě ",				// note the space on the end
 			"Makra",
 			"Chyba ",						// note the space at the end
-			" pÅ™Ã­stupu ke kartÄ›",			// note the space at the start
-			"NÃ¡zev: ",
+			" přístupu ke kartě",			// note the space at the start
+			"Název: ",
 			"Velikost: ",
-			"VÃ½Å¡ka vrstvy: ",
-			"VÃ½Å¡ka objektu: ",
-			"SpotÅ™eba (mat.): ",
+			"Výška vrstvy: ",
+			"Výška objektu: ",
+			"Spotřeba (mat.): ",
 			"Slicer: ",
 			"Simulace",
 
 			// Printer status strings
 			{
-				"PÅ™ipojovÃ¡nÃ­",
-				"NeÄ�innÃ½",
+				"Připojování",
+				"Nečinný",
 				"Tiskne",
 				"Zastaven",
 				"Startuje",
 				"Pozastaven",
-				"ZaneprÃ¡zdnÄ›nÃ½",
+				"Zaneprázdněný",
 				"Pozastavuje se",
-				"PokraÄ�uje",
-				"NahrÃ¡vÃ¡ firmware",
-				"VÃ½mÄ›na nÃ¡stroje",
+				"Pokračuje",
+				"Nahrává firmware",
+				"Výměna nástroje",
 				"Simulace"
 			},
 
 			// Theme names
 			{
-				"SvÄ›tlÃ½",
-				"TmavÃ½"
+				"Světlý",
+				"Tmavý"
 			},
 			// display dimming types
 			{
-				"Vždy dim",
+				"Vždy Dim",
 				"Nikdy nezměníme",
 				"Idle Dim"
 			}
-
 		},
 
 #if 0	// Spanish not supported yet
@@ -624,7 +620,7 @@ const StringTable LanguageTables[4] =
 
 		// Printer status strings
 		{
-			"conexiÃ³n",
+			"conexión",
 			"ocioso",
 			"imprimiendo",
 			"detuvo",

--- a/src/Strings.hpp
+++ b/src/Strings.hpp
@@ -101,6 +101,9 @@ struct StringTable
 
 	// Colour theme names
 	CSTRING colourSchemeNames[NumColourSchemes];
+
+	// display dimmer types
+	CSTRING displayDimmingNames[DISPLAYDIMMER_MAX+1];
 };
 
 const StringTable LanguageTables[4] =
@@ -204,6 +207,13 @@ const StringTable LanguageTables[4] =
 		{
 			"Light",
 			"Dark"
+		},
+
+		// display dimming types
+		{
+			"Always Dim",
+			"Never Dim",
+			"Idle Dim"
 		}
 	},
 
@@ -228,8 +238,8 @@ const StringTable LanguageTables[4] =
 		// Print page
 		"Extruder" THIN_SPACE "%",
 		"Speed ",							// note space at end. Was "Geschwindigkeit " but that is too long to fit in the space available.
-		"Lüfter ",							// note space at end
-		"Zeit übrig: ",
+		"LÃ¼fter ",							// note space at end
+		"Zeit Ã¼brig: ",
 		"Datei ",							// note space at end
 		", Filament ",						// note space at end
 		", Schicht ",						// note space at end
@@ -241,7 +251,7 @@ const StringTable LanguageTables[4] =
 		"Set",
 
 		// Setup page
-		"Lautstärke ",						// note space at end
+		"LautstÃ¤rke ",						// note space at end
 		"Touch kalibrieren",
 		"Anzeige spiegeln",
 		"Anzeige invertieren",
@@ -249,24 +259,24 @@ const StringTable LanguageTables[4] =
 		"Helligkeit -",
 		"Helligkeit +",
 		"Einstellungen speichern",
-		"Einstellungen löschen",
+		"Einstellungen lÃ¶schen",
 		"Speichern & Neustarten",
 
 		// Misc
-		"Rücksetzen bestätigen",
-		"Neustart bestätigen",
-		"Löschen bestätigen",
+		"RÃ¼cksetzen bestÃ¤tigen",
+		"Neustart bestÃ¤tigen",
+		"LÃ¶schen bestÃ¤tigen",
 		"Sind sie sicher?",
-		"Berühren sie den Punkt",
+		"BerÃ¼hren sie den Punkt",
 		"Einige Einstellungen sind nicht gespeichert!",
-		"Berühren sie Speichern & Neustarten um die neuen Einstellungen anzuwenden",
+		"BerÃ¼hren sie Speichern & Neustarten um die neuen Einstellungen anzuwenden",
 		"Neustarten erforderlich",
 		"Neustarten jetzt?",
 		"Kopf bewegen",
 		"Extrusionsmenge (mm)",
 		"Geschwindigkeit (mm/s)",
 		"Extrudieren",
-		"Zurückziehen",
+		"ZurÃ¼ckziehen",
 		"Babystepping",
 		"Aktueller Z-Versatz: ",
 		"Nachricht",
@@ -279,10 +289,10 @@ const StringTable LanguageTables[4] =
 		"Fehler ",						// note the space at the end
 		" beim Zugriff auf SD-Karte",	// note the space at the start
 		"Dateiname: ",
-		"Größe: ",
-		"Schichthöhe: ",
-		"Objekthöhe: ",
-		"Benötigtes Filament: ",
+		"GrÃ¶ÃŸe: ",
+		"SchichthÃ¶he: ",
+		"ObjekthÃ¶he: ",
+		"BenÃ¶tigtes Filament: ",
 		"Erzeugt mit: ",
 		"Simulieren",
 
@@ -294,7 +304,7 @@ const StringTable LanguageTables[4] =
 			"Angehalten",
 			"Starte",
 			"Pausiert",
-			"Beschäftigt",
+			"BeschÃ¤ftigt",
 			"Pausiere",
 			"Fortsetzen",
 			"Firmware-Upload",
@@ -306,16 +316,25 @@ const StringTable LanguageTables[4] =
 		{
 			"Hell",
 			"Dunkel"
+		},
+
+		// display dimming types
+		{
+			"Immer Dim",
+			"Nie dämmern",
+			"Idle Dim"
 		}
+
+
 	},
 
 	// French
 	{
 		// Language name
-		"Français",
+		"FranÃ§ais",
 
 		// Main page strings
-		"Contrôle",
+		"ContrÃ´le",
 		"Imprimer",
 		"Console",
 		"Installation",
@@ -325,7 +344,7 @@ const StringTable LanguageTables[4] =
 		"Mouvement",
 		"Extrusion",
 		"Macro",
-		"ARRÊT",
+		"ARRÃŠT",
 
 		// Print page
 		"Extrudeuse" THIN_SPACE "%",
@@ -345,32 +364,32 @@ const StringTable LanguageTables[4] =
 		// Setup page
 		"Volume ",								// note space at end
 		"Calibrer touch",
-		"Affichage en négatif",
+		"Affichage en nÃ©gatif",
 		"Inverser affichage",
-		"Théme",
-		"Luminosité -",
-		"Luminosité +",
-		"Sauver paramêtres",
-		"Effacer paramêtres",
-		"Sauvegarde & Redémarrage",
+		"ThÃ©me",
+		"LuminositÃ© -",
+		"LuminositÃ© +",
+		"Sauver paramÃªtres",
+		"Effacer paramÃªtres",
+		"Sauvegarde & RedÃ©marrage",
 
 		// Misc
-		"Confirmer le réinitialisation de l'imprimante",
-		"Confirm Redémarrage",
+		"Confirmer le rÃ©initialisation de l'imprimante",
+		"Confirm RedÃ©marrage",
 		"Confirm suppression fichier",
-		"Vous êtes sûre?",
+		"Vous Ãªtes sÃ»re?",
 		"Appuyer sur le point",
-		"Certains réglages ne sont pas sauvegardés!",
-		"Appuyer sur Sauvegarde et Redémarrage pour utiliser les nouveaux réglages",
+		"Certains rÃ©glages ne sont pas sauvegardÃ©s!",
+		"Appuyer sur Sauvegarde et RedÃ©marrage pour utiliser les nouveaux rÃ©glages",
 		"Restart required",
 		"Restart now?",
-		"Mouvement de la  tête",
-		"Quantité de Matiére extrudée (mm)",
+		"Mouvement de la  tÃªte",
+		"QuantitÃ© de MatiÃ©re extrudÃ©e (mm)",
 		"Vitesse (mm/s)",
 		"Extruder",
 		"Retracter",
 		"Baby stepping",
-		"décalage Z courant : ",
+		"dÃ©calage Z courant : ",
 		"Message",
 		"Messages",
 		"Version du firmware du Panel Due ",	// note space at end
@@ -379,7 +398,7 @@ const StringTable LanguageTables[4] =
 		"Fichier sur carte ",					// note the space on the end
 		"Macros",
 		"Erreur ",								// note the space at the end
-		" accés SD card en cours",				// note the space at the start
+		" accÃ©s SD card en cours",				// note the space at the start
 		"Nom du fichier : ",
 		"Taille : ",
 		"Hauteur de couche: ",
@@ -393,13 +412,13 @@ const StringTable LanguageTables[4] =
 			"Connection en cours",
 			"Au repos",
 			"Impression",
-			"Arrêt",
-			"Démarrage",
+			"ArrÃªt",
+			"DÃ©marrage",
 			"Pause",
-			"Occupé"
+			"OccupÃ©"
 			"Pause",
 			"Reprise",
-			"Téleverser le firmware",
+			"TÃ©leverser le firmware",
 			"Changement d'outil",
 			"Simuler"
 		},
@@ -408,21 +427,29 @@ const StringTable LanguageTables[4] =
 		{
 			"Fond Blanc",
 			"Fond Noir"
+		},
+
+		// display dimming types
+		{
+			"Toujours Dim",
+			"Jamais Dim",
+			"Idle Dim"
 		}
+
 	},
 	// Czech
 		{
 			// Language name
-			"Čeština",
+			"ÄŒeÅ¡tina",
 
 			// Main page strings
-			"Ovládání",
+			"OvlÃ¡dÃ¡nÃ­",
 			"Tisk",
 			"Konzole",
-			"Nastavení",
-			"Aktuální" THIN_SPACE DEGREE_SYMBOL "C",
-			"Aktivní" THIN_SPACE DEGREE_SYMBOL "C",
-			"Nečinná" THIN_SPACE DEGREE_SYMBOL "C",
+			"NastavenÃ­",
+			"AktuÃ¡lnÃ­" THIN_SPACE DEGREE_SYMBOL "C",
+			"AktivnÃ­" THIN_SPACE DEGREE_SYMBOL "C",
+			"NeÄ�innÃ¡" THIN_SPACE DEGREE_SYMBOL "C",
 			"Pohyb",
 			"Extruder",
 			"Makra",
@@ -432,83 +459,90 @@ const StringTable LanguageTables[4] =
 			"Extruder" THIN_SPACE "%",
 			"Rychl. ",							// note space at end
 			"Vent. ",							// note space at end
-			"Čas do konce: ",
+			"ÄŒas do konce: ",
 			"soubor ",							// note space at end
-			", materiál ",						// note space at end
+			", materiÃ¡l ",						// note space at end
 			", vrstva ",							// note space at end
 			"n/a",
 			"Pozastavit",
 			"Baby step",
-			"Pokračovat",
-			"Zrušit",
+			"PokraÄ�ovat",
+			"ZruÅ¡it",
 			"OK",
 
 			// Setup page
 			"Hlasitost ",							// note space at end
 			"Kalibrace dotyku",
 			"Zrcadlit displej",
-			"Obrátit displej",
+			"ObrÃ¡tit displej",
 			"Motiv",
-			"Podsvícení -",
-			"Podsvícení +",
-			"Uložit nastavení",
-			"Smazat nastavení",
-			"Uložit a Restart",
+			"PodsvÃ­cenÃ­ -",
+			"PodsvÃ­cenÃ­ +",
+			"UloÅ¾it nastavenÃ­",
+			"Smazat nastavenÃ­",
+			"UloÅ¾it a Restart",
 
 			// Misc
-			"Skutečně obnovit tovární nastavení?",
+			"SkuteÄ�nÄ› obnovit tovÃ¡rnÃ­ nastavenÃ­?",
 			"Restartovat?",
-			"Skutečně smazat?",
-			"Určitě?",
-			"Dotkněte se bodu",
-			"Některá nastavení nejsou uložena!",
-			"Zvolte Uložit a Restart pro dokončení",
-			"Vyžadován restart",
-			"Restartovat nyní?",
+			"SkuteÄ�nÄ› smazat?",
+			"UrÄ�itÄ›?",
+			"DotknÄ›te se bodu",
+			"NÄ›kterÃ¡ nastavenÃ­ nejsou uloÅ¾ena!",
+			"Zvolte UloÅ¾it a Restart pro dokonÄ�enÃ­",
+			"VyÅ¾adovÃ¡n restart",
+			"Restartovat nynÃ­?",
 			"Posun hlavy",
-			"Množství (mm)",
+			"MnoÅ¾stvÃ­ (mm)",
 			"Rychlost (mm/s)",
-			"Vytlačit (extr.)",
-			"Zatlačit (retr.)",
+			"VytlaÄ�it (extr.)",
+			"ZatlaÄ�it (retr.)",
 			"Baby stepping",
-			"Aktuální Z offset: ",
-			"Zpráva",
-			"Zprávy",
+			"AktuÃ¡lnÃ­ Z offset: ",
+			"ZprÃ¡va",
+			"ZprÃ¡vy",
 			"Verze firmware Panel Due ",	// note space at end
 			// File popup
-			"Soubory na kartě ",				// note the space on the end
+			"Soubory na kartÄ› ",				// note the space on the end
 			"Makra",
 			"Chyba ",						// note the space at the end
-			" přístupu ke kartě",			// note the space at the start
-			"Název: ",
+			" pÅ™Ã­stupu ke kartÄ›",			// note the space at the start
+			"NÃ¡zev: ",
 			"Velikost: ",
-			"Výška vrstvy: ",
-			"Výška objektu: ",
-			"Spotřeba (mat.): ",
+			"VÃ½Å¡ka vrstvy: ",
+			"VÃ½Å¡ka objektu: ",
+			"SpotÅ™eba (mat.): ",
 			"Slicer: ",
 			"Simulace",
 
 			// Printer status strings
 			{
-				"Připojování",
-				"Nečinný",
+				"PÅ™ipojovÃ¡nÃ­",
+				"NeÄ�innÃ½",
 				"Tiskne",
 				"Zastaven",
 				"Startuje",
 				"Pozastaven",
-				"Zaneprázdněný",
+				"ZaneprÃ¡zdnÄ›nÃ½",
 				"Pozastavuje se",
-				"Pokračuje",
-				"Nahrává firmware",
-				"Výměna nástroje",
+				"PokraÄ�uje",
+				"NahrÃ¡vÃ¡ firmware",
+				"VÃ½mÄ›na nÃ¡stroje",
 				"Simulace"
 			},
 
 			// Theme names
 			{
-				"Světlý",
-				"Tmavý"
+				"SvÄ›tlÃ½",
+				"TmavÃ½"
+			},
+			// display dimming types
+			{
+				"Vždy dim",
+				"Nikdy nezměníme",
+				"Idle Dim"
 			}
+
 		},
 
 #if 0	// Spanish not supported yet
@@ -590,7 +624,7 @@ const StringTable LanguageTables[4] =
 
 		// Printer status strings
 		{
-			"conexión",
+			"conexiÃ³n",
 			"ocioso",
 			"imprimiendo",
 			"detuvo",

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -71,7 +71,7 @@ static StaticTextField *moveAxisRows[MaxAxes];
 static StaticTextField *nameField, *statusField, *settingsNotSavedField;
 static IntegerButton *activeTemps[MaxHeaters], *standbyTemps[MaxHeaters];
 static IntegerButton *spd, *extrusionFactors[MaxHeaters - 1], *fanSpeed, *baudRateButton, *volumeButton;
-static TextButton *languageButton, *coloursButton;
+static TextButton *languageButton, *coloursButton, *dimmingTypeButton;
 static SingleButton *moveButton, *extrudeButton, *macroButton;
 static PopupWindow *babystepPopup;
 static AlertPopup *alertPopup;
@@ -336,6 +336,17 @@ void ChangeBrightness(bool up)
 		adjust = -adjust;
 	}
 	SetBrightness(GetBrightness() + adjust);
+}
+
+// cycle through available display dimmer types
+void ChangeDisplayDimmerType()
+{
+	DisplayDimmerTypes newType = (DisplayDimmerTypes) ((uint8_t)GetDisplayDimmerType() + 1);
+	if (newType > DISPLAYDIMMER_MAX)
+	{
+		newType = (DisplayDimmerTypes) 0;
+	}
+	SetDisplayDimmerType(newType);
 }
 
 // Update an integer field, provided it isn't the one being adjusted
@@ -879,9 +890,11 @@ void CreateSetupTabFields(uint32_t language, const ColourScheme& colours)
 	coloursButton->SetText(strings->colourSchemeNames[colours.index]);
 	AddTextButton(row6, 1, 3, strings->brightnessDown, evDimmer, nullptr);
 	AddTextButton(row6, 2, 3, strings->brightnessUp, evBrighter, nullptr);
-	AddTextButton(row7, 0, 3, strings->saveSettings, evSaveSettings, nullptr);
-	AddTextButton(row7, 1, 3, strings->clearSettings, evFactoryReset, nullptr);
-	AddTextButton(row7, 2, 3, strings->saveAndRestart, evRestart, nullptr);
+	dimmingTypeButton = AddTextButton(row7, 0, 3, strings->displayDimmingNames[GetDisplayDimmerType()], evSetDimmingType, nullptr);
+	dimmingTypeButton->SetText(strings->displayDimmingNames[GetDisplayDimmerType()]);
+	AddTextButton(row8, 0, 3, strings->saveSettings, evSaveSettings, nullptr);
+	AddTextButton(row8, 1, 3, strings->clearSettings, evFactoryReset, nullptr);
+	AddTextButton(row8, 2, 3, strings->saveAndRestart, evRestart, nullptr);
 	setupRoot = mgr.GetRoot();
 }
 
@@ -1965,6 +1978,12 @@ namespace UI
 					languageButton->SetText(LanguageTables[newLanguage].languageName);
 				}
 				CheckSettingsAreSaved();						// not sure we need this because we are going to reset anyway
+				break;
+
+			case evSetDimmingType:
+				ChangeDisplayDimmerType();
+				dimmingTypeButton->SetText(strings->displayDimmingNames[GetDisplayDimmerType()]);
+				CheckSettingsAreSaved();
 				break;
 
 			case evYes:


### PR DESCRIPTION
(These are changes I'd previously suggested in a forum post that don't change behavior.)

First, move the code for dimming the display to a function (similar to RestoreBrightness().)  At the moment, this is really a NOP as it's only used in one place.  

Then change RestoreBrightness() to also reset the lastActionTime.  This allows code to call RestoreBrightness() without concern that the main() loop will instantly re-dim the display due to the timer not getting reset.  (lastActionTime doesn't seem to be used for any purpose other than the display dimmer timer.)