### PR TITLE
Fix for not clearing file/macro buttons no longer used.

### DIFF
--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2255,7 +2255,7 @@ namespace UI
 	void UpdateFileButton(bool filesNotMacros, unsigned int buttonIndex, const char * array null text, const char * array null param)
 	{
 		TextButton * const f = ((filesNotMacros) ? filenameButtons : macroButtons)[buttonIndex];
-		f->SetText(text);
+		f->SetText(text != nullptr ? text : "");
 		f->SetEvent((text == nullptr) ? evNull : (filesNotMacros) ? evFile : evMacro, param);
 		mgr.Show(f, text != nullptr);
 	}


### PR DESCRIPTION
Using previous revisions as a guide, if the text for a text button is null, use SetText with an empty string (instead of a null pointer.)  This resolves the issue of file/macro lists not clearing "buttons" that are not used (such as when navigating from a very full directory to a nearly empty subdirectory.)