### PR TITLE
fix for macros at control page

### DIFF
--- a/src/Events.hpp
+++ b/src/Events.hpp
@@ -32,7 +32,7 @@ enum Event : uint8_t
 	evSetInt,
 	evListFiles,
 
-	evFile, evMacro,
+	evFile, evMacro, evMacroControlPage,
 	evPrintFile,
 	evSendCommand,
 	evFactoryReset,

--- a/src/FileManager.cpp
+++ b/src/FileManager.cpp
@@ -442,6 +442,11 @@ namespace FileManager
 		return macroFilesList.GetPath();
 	}
 
+	const char * array GetMacrosRootDir()
+	{
+		return macrosRoot;
+	}
+
 	void RefreshFilesList()
 	{
 		gcodeFilesList.SetPending();

--- a/src/FileManager.hpp
+++ b/src/FileManager.hpp
@@ -76,6 +76,7 @@ namespace FileManager
 	void RequestMacrosParentDir();
 	const char * array GetFilesDir();
 	const char * array GetMacrosDir();
+	const char * array GetMacrosRootDir();
 
 	void RefreshFilesList();
 	void RefreshMacrosList();

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -772,7 +772,7 @@ void CreateControlTabFields(const ColourScheme& colours)
 	for (size_t i = 0; i < NumControlPageMacroButtons; ++i)
 	{
 		// The position and width of the buttons will get corrected when we know how many tools we have
-		TextButton *b = controlPageMacroButtons[i] = new TextButton(row2 + i * rowHeight, 999, 99, nullptr, evMacro);
+		TextButton *b = controlPageMacroButtons[i] = new TextButton(row2 + i * rowHeight, 999, 99, nullptr, evNull);
 		b->Show(false);			// hide them until we have loaded the macros
 		mgr.AddField(b);
 	}
@@ -1870,6 +1870,7 @@ namespace UI
 				break;
 
 			case evMacro:
+			case evMacroControlPage:
 				{
 					const char *fileName = bp.GetSParam();
 					if (fileName != nullptr)
@@ -1882,7 +1883,7 @@ namespace UI
 						else
 						{
 							SerialIo::SendString("M98 P");
-							SerialIo::SendFilename(CondStripDrive(FileManager::GetMacrosDir()), fileName);
+							SerialIo::SendFilename(ev == evMacroControlPage ? CondStripDrive(FileManager::GetMacrosRootDir()) : CondStripDrive(FileManager::GetMacrosDir()), fileName);
 							SerialIo::SendChar('\n');
 						}
 					}
@@ -2299,7 +2300,7 @@ namespace UI
 		}
 		TextButton * const f = controlPageMacroButtons[buttonIndex];
 		f->SetText(SkipDigitsAndUnderscore(str.c_str()));
-		f->SetEvent((isFile) ? evMacro : evNull, str.c_str());
+		f->SetEvent((isFile) ? evMacroControlPage : evNull, str.c_str());
 		mgr.Show(f, isFile);
 		return true;
 	}


### PR DESCRIPTION
Unfortunately bug #29 was not fixed in 1.21.2.

This was caused by always using the current directory (the last one which was entered before executing the macro from the control screen).

I've added a new event to distinguish between macro events executed from control screen and from the macro view.