### PR TITLE
When "off", a device is idle

### DIFF
--- a/src/PanelDue.cpp
+++ b/src/PanelDue.cpp
@@ -506,7 +506,7 @@ extern void RestoreBrightness()
 extern void DimBrightness()
 {
 	if (   (GetDisplayDimmerType() == DisplayDimmerType::always)
-		|| (GetDisplayDimmerType() == DisplayDimmerType::onIdle && (status == PrinterStatus::idle) || (status == PrinterStatus::off))
+		|| ((GetDisplayDimmerType() == DisplayDimmerType::onIdle) && ((status == PrinterStatus::idle) || (status == PrinterStatus::off))))
 	   )
 	{
 		Buzzer::SetBacklight(nvData.brightness/8);

--- a/src/PanelDue.cpp
+++ b/src/PanelDue.cpp
@@ -506,7 +506,7 @@ extern void RestoreBrightness()
 extern void DimBrightness()
 {
 	if (   (GetDisplayDimmerType() == DisplayDimmerType::always)
-		|| (GetDisplayDimmerType() == DisplayDimmerType::onIdle && status == PrinterStatus::idle)
+		|| (GetDisplayDimmerType() == DisplayDimmerType::onIdle && (status == PrinterStatus::idle) || (status == PrinterStatus::off))
 	   )
 	{
 		Buzzer::SetBacklight(nvData.brightness/8);


### PR DESCRIPTION
For the purpose of dimming a display when it is idle, consider the "off" state as being the same as idle.  (I typed this change in the github web interface, so there might be a mismatched paren))