### PR TITLE
Block evSelectHead while printing

### DIFF
--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1857,15 +1857,19 @@ namespace UI
 					}
 					else if (head < (int)MaxHeaters)
 					{
-						if (heaterStatus[head] == 2)		// if head is active
+						// pressing a evSeelctHead button in the middle of active printing is almost always accidental (and fatal to the print job)
+						if (GetStatus() != PrinterStatus::printing && GetStatus() != PrinterStatus::simulating)
 						{
-							SerialIo::SendString("T-1\n");
-						}
-						else
-						{
-							SerialIo::SendChar('T');
-							SerialIo::SendInt(head - 1);
-							SerialIo::SendChar('\n');
+							if (heaterStatus[head] == 2)		// if head is active
+							{
+								SerialIo::SendString("T-1\n");
+							}
+							else
+							{
+								SerialIo::SendChar('T');
+								SerialIo::SendInt(head - 1);
+								SerialIo::SendChar('\n');
+							}
 						}
 					}
 				}


### PR DESCRIPTION
If a button for selecting/deselecting a tool (heater/head) is pressed mid-print, it's almost always an accidental press, but always fatal to the print.  So, don't react to the button while printing.  If the user knows what they are doing, they can use the console to manually send "T" gcode commands.